### PR TITLE
Remove @csrf_exempt and harden CSRF protection

### DIFF
--- a/code/llmsite/llmsite/settings.py
+++ b/code/llmsite/llmsite/settings.py
@@ -144,3 +144,8 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 # Site configuration
 SITE_ID = 1
 
+# CSRF cookie hardening
+# Note: CSRF_COOKIE_HTTPONLY must remain False because the frontend
+# reads the CSRF token from the cookie via JavaScript (getCookie("csrftoken")).
+CSRF_COOKIE_SECURE = True
+

--- a/code/llmsite/tutor/templates/chat_api.html
+++ b/code/llmsite/tutor/templates/chat_api.html
@@ -115,9 +115,9 @@
     try {
       const res = await fetch("{% url 'api_chat' %}", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "X-CSRFToken": csrftoken },
         credentials: "same-origin",
-        body: JSON.stringify({ 
+        body: JSON.stringify({
           message: text,
           session_id: currentSessionId
         })

--- a/code/llmsite/tutor/views.py
+++ b/code/llmsite/tutor/views.py
@@ -2,7 +2,6 @@ from django.http import FileResponse, Http404, HttpResponseRedirect, JsonRespons
 from django.contrib.auth.models import AnonymousUser
 from django.shortcuts import render
 from django.views.decorators.http import require_http_methods, require_GET
-from django.views.decorators.csrf import csrf_exempt
 from django.contrib.auth.decorators import login_required, user_passes_test
 from django.contrib.auth import login, get_user_model
 from django.shortcuts import render, redirect, get_object_or_404
@@ -403,7 +402,6 @@ def student_edit(request):
     return redirect("dashboard")
 
 
-@csrf_exempt
 @require_http_methods(["POST"])
 @login_required
 def api_new_session(request):
@@ -494,8 +492,8 @@ def api_new_session(request):
     })
 
 
-@csrf_exempt
 @require_http_methods(["POST"])
+@login_required
 def api_init(request):
     import time
     print("api_init called at", time.time())
@@ -556,7 +554,6 @@ def api_init(request):
         """
         pass
 
-#@csrf_exempt
 @require_http_methods(["POST"])
 def api_chat(request):
     try:
@@ -673,8 +670,8 @@ def api_chat(request):
         return JsonResponse({"ok": True, "model_text": assistant_reply_text})
 
 
-@csrf_exempt
 @require_http_methods(["POST"])
+@login_required
 def api_reset(request):
     sid = _session_id(request)
     CHAT_REGISTRY.pop(sid, None)
@@ -1047,7 +1044,6 @@ def api_session_messages(request, session_id):
     return JsonResponse({"ok": True, "messages": messages, "quiz_attempts": quiz_attempts})
 
 
-@csrf_exempt
 @require_http_methods(["POST"])
 @login_required
 def api_session_init(request, session_id):
@@ -1090,7 +1086,6 @@ def api_session_init(request, session_id):
     return JsonResponse({"ok": True, "model_text": assistant_msg or "Hello!"})
 
 
-@csrf_exempt
 @require_http_methods(["DELETE"])
 @login_required
 def api_delete_session(request, session_id):
@@ -1100,7 +1095,6 @@ def api_delete_session(request, session_id):
     return JsonResponse({"ok": True, "status": "deleted"})
 
 
-@csrf_exempt
 @require_http_methods(["POST"])
 @login_required
 def api_rename_session(request, session_id):
@@ -1117,7 +1111,6 @@ def api_rename_session(request, session_id):
     return JsonResponse({"ok": True, "id": str(session.id), "title": session.title})
 
 
-@csrf_exempt
 @require_http_methods(["POST"])
 @login_required
 def api_select_session(request, session_id):


### PR DESCRIPTION
## Summary
- Removed `@csrf_exempt` from 7 API endpoints that unnecessarily bypassed CSRF protection (the frontend already sends CSRF tokens via `X-CSRFToken` header)
- Added `@login_required` to `api_init` and `api_reset` which were previously accessible without authentication
- Added missing `X-CSRFToken` header to `chat_api.html` fetch call for `api_chat`
- Enabled `CSRF_COOKIE_SECURE = True` for HTTPS environments

Fixes #37

## Test plan
- [x] All 6 existing Django tests pass
- [ ] Verify chat functionality works end-to-end (send message, receive response)
- [ ] Verify session creation, rename, delete still work
- [ ] Verify quiz grading still works
- [ ] Confirm CSRF token is sent in all frontend fetch requests
