### PR TITLE
Render markdown and LaTeX in chat teacher bubbles

### DIFF
--- a/code/llmsite/tutor/templates/chat.html
+++ b/code/llmsite/tutor/templates/chat.html
@@ -85,6 +85,10 @@
 {% endblock %}
 
 {% block scripts %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
+<script src="https://cdn.jsdelivr.net/npm/marked@14.1.3/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
 <script>
   // --- CSRF helpers (must be first) ---
   function getCookie(name) {
@@ -316,7 +320,7 @@
           ? `<span class='text-brand-700'>Correct</span>`
           : `<span class='text-red-600'>Incorrect</span>`;
         if (explanation) {
-          formatted += `<div class='text-sm text-gray-700 mt-1'>${explanation}</div>`;
+          formatted += `<div class='text-sm text-gray-700 mt-1'>${renderMarkdownWithMath(explanation)}</div>`;
         }
         formatted += `</div></div>`;
       });
@@ -348,7 +352,7 @@
       });
       if (!res.ok) throw new Error(await res.text());
       const data = await res.json();
-      initialChat.innerText = data.model_text || "(no text)";
+      initialChat.innerHTML = renderMarkdownWithMath(data.model_text || "(no text)");
     } catch (err) {
       initialChat.innerText = "Error: " + err.message;
     }
@@ -387,8 +391,64 @@
 
   function formatTeacherMessage(text, quizAttempt) {
     const quizObj = parseQuizJson(text);
-    if (!quizObj) return escapeHtml(text);
+    if (!quizObj) return renderMarkdownWithMath(text);
     return renderReadOnlyQuiz(quizObj, quizAttempt);
+  }
+
+  // --- Markdown + LaTeX rendering ---
+  // Strategy: extract math spans to placeholders BEFORE markdown parsing so
+  // marked's emphasis/italic parser does not corrupt things like $a_b$ or $x^2$.
+  // Then render each extracted expression with KaTeX and splice back in.
+  function renderMarkdownWithMath(text) {
+    const src = String(text || "");
+    if (!src) return "";
+    const placeholders = [];
+    const takePlaceholder = (expr, display) => {
+      const idx = placeholders.length;
+      placeholders.push({ expr: String(expr || "").trim(), display: !!display });
+      return `@@MATH_${idx}@@`;
+    };
+
+    // Block math: $$...$$  and  \[...\]
+    let working = src
+      .replace(/\$\$([\s\S]+?)\$\$/g, (_, expr) => takePlaceholder(expr, true))
+      .replace(/\\\[([\s\S]+?)\\\]/g, (_, expr) => takePlaceholder(expr, true));
+
+    // Inline math: $...$  and  \(...\)
+    // Tolerate the model's occasional "$ expr $" (surrounding whitespace).
+    working = working
+      .replace(/\$\s*([^$\n]+?)\s*\$/g, (_, expr) => takePlaceholder(expr, false))
+      .replace(/\\\(([\s\S]+?)\\\)/g, (_, expr) => takePlaceholder(expr, false));
+
+    let html;
+    try {
+      html = (typeof marked !== "undefined" && marked.parse)
+        ? marked.parse(working, { breaks: true, gfm: true })
+        : escapeHtml(working).replace(/\n/g, "<br>");
+    } catch (e) {
+      html = escapeHtml(working).replace(/\n/g, "<br>");
+    }
+
+    html = html.replace(/@@MATH_(\d+)@@/g, (_, i) => {
+      const ph = placeholders[Number(i)];
+      if (!ph) return "";
+      if (typeof katex === "undefined") return escapeHtml(ph.expr);
+      try {
+        return katex.renderToString(ph.expr, {
+          throwOnError: false,
+          displayMode: ph.display,
+        });
+      } catch (e) {
+        return `<code>${escapeHtml(ph.expr)}</code>`;
+      }
+    });
+
+    if (typeof DOMPurify !== "undefined") {
+      return DOMPurify.sanitize(html, {
+        ADD_ATTR: ["style", "aria-hidden"],
+      });
+    }
+    return html;
   }
 
   function renderReadOnlyQuiz(quizObj, quizAttempt) {


### PR DESCRIPTION
## Summary
- Chat previously HTML-escaped all model output, so markdown (`**bold**`, `###`, `---`) and LaTeX math (`$x^2$`, `$$...$$`) displayed as raw source in teacher bubbles and quiz-feedback explanations.
- Load `marked`, `KaTeX`, and `DOMPurify` from CDN (matches the existing Tailwind-via-CDN pattern in `base.html`).
- Add `renderMarkdownWithMath()` that extracts math spans to placeholders **before** markdown parsing, so `marked`'s emphasis/italic parser cannot corrupt expressions like `$a_b$` or `$x^2$`. Supports `$...$`, `$$...$$`, `\(...\)`, `\[...\]`, and tolerates the model's occasional `$ expr $` whitespace.
- Use the helper for non-quiz teacher bubbles, quiz-feedback explanations, and the initial session greeting.
- Sanitize rendered HTML with DOMPurify, preserving KaTeX's inline styles and aria attributes.

Quiz card and read-only-quiz rendering are intentionally untouched — those are part of the follow-up quiz-card PR.

## Test plan
- [ ] Run the Django dev server and open `/chat/`.
- [ ] Ask "quick explanation on combining like terms" — confirm `###`, `**bold**`, and `$3x$`-style math render as formatted text and math, not raw source.
- [ ] Ask a question whose answer contains `$$...$$` block math — confirm it renders as display math.
- [ ] Confirm a user-typed message containing `<script>alert(1)</script>` does **not** execute (user bubbles still `escapeHtml`).
- [ ] Submit a quiz (without touching the card yet) and confirm the feedback modal renders explanations with markdown/math.
- [ ] Confirm the initial greeting renders markdown if the model emits any.
