### PR TITLE
Persist quizzes, refresh progress after grading, render math in quiz cards

### DIFF
--- a/code/llmsite/tutor/templates/chat.html
+++ b/code/llmsite/tutor/templates/chat.html
@@ -222,16 +222,19 @@
     quizForm.innerHTML = "";
 
     Object.entries(quizObj).forEach(([qid, qdata]) => {
+      const safeQid = escapeHtml(String(qid));
+      const questionHtml = renderMarkdownWithMath(qdata.question || "");
       let html = "";
-      html += `<div class='mb-2'><label class='font-semibold'>${qdata.question}</label>`;
+      html += `<div class='mb-2'><label class='font-semibold block'>${questionHtml}</label>`;
       if (qdata.type === "multiple-choice" && qdata.answers) {
         html += `<div class='space-y-1 mt-1'>`;
         qdata.answers.forEach((ans, i) => {
-          html += `<label class='flex items-center gap-2'><input type='radio' name='${qid}' value='${i + 1}' class='form-radio'>${ans}</label>`;
+          const answerHtml = renderMarkdownWithMath(String(ans ?? ""));
+          html += `<label class='flex items-center gap-2'><input type='radio' name='${safeQid}' value='${i + 1}' class='form-radio'><span>${answerHtml}</span></label>`;
         });
         html += `</div>`;
       } else if (qdata.type === "short-answer") {
-        html += `<input type='text' name='${qid}' class='mt-1 rounded border px-2 py-1 w-full'>`;
+        html += `<input type='text' name='${safeQid}' class='mt-1 rounded border px-2 py-1 w-full'>`;
       }
       html += `</div>`;
       quizForm.innerHTML += html;
@@ -326,7 +329,7 @@
       });
       formatted += `</div>`;
     } else {
-      formatted = `<pre class='text-sm'>${feedbackText}</pre>`;
+      formatted = `<pre class='text-sm'>${escapeHtml(String(feedbackText ?? ""))}</pre>`;
     }
     quizFeedbackContent.innerHTML = formatted;
     quizFeedbackModal.classList.remove("hidden");
@@ -474,7 +477,7 @@
       const isCorrect = attempt && typeof attempt.is_correct === "boolean" ? attempt.is_correct : null;
 
       html += `<div class="rounded-xl border border-gray-200 bg-white p-3 space-y-2">`;
-      html += `<div class="text-sm font-semibold text-gray-900">${idx + 1}. ${escapeHtml(question)}</div>`;
+      html += `<div class="text-sm font-semibold text-gray-900">${idx + 1}. ${renderMarkdownWithMath(question)}</div>`;
 
       if (qType === "multiple-choice" && Array.isArray(qdata.answers)) {
         html += `<ul class="space-y-1">`;
@@ -487,7 +490,7 @@
             ? "bg-green-100 text-green-800 border border-green-300"
             : (isStudentChoice ? "bg-blue-100 text-blue-800 border border-blue-300" : "text-gray-700");
           html += `<li class="rounded-md px-2 py-1 text-sm ${liClass}">`;
-          html += `${escapeHtml(choiceNumber)}. ${escapeHtml(choiceText)}`;
+          html += `${escapeHtml(choiceNumber)}. ${renderMarkdownWithMath(choiceText)}`;
           if (isRightChoice) html += ` <span class="ml-1 font-semibold">(Correct answer)</span>`;
           if (isStudentChoice && !isRightChoice) html += ` <span class="ml-1 font-semibold">(Student answer)</span>`;
           if (isStudentChoice && isRightChoice) html += ` <span class="ml-1 font-semibold">(Student answered this)</span>`;
@@ -495,11 +498,11 @@
         });
         html += `</ul>`;
       } else {
-        html += `<div class="text-sm text-gray-700">Correct answer: <span class="font-semibold text-green-700">${escapeHtml(correct || "N/A")}</span></div>`;
+        html += `<div class="text-sm text-gray-700">Correct answer: <span class="font-semibold text-green-700">${renderMarkdownWithMath(correct || "N/A")}</span></div>`;
       }
 
       if (attempt && attempt.has_submission) {
-        html += `<div class="text-sm text-gray-700">Student answer: <span class="font-semibold ${isCorrect === true ? "text-green-700" : (isCorrect === false ? "text-red-700" : "text-gray-800")}">${escapeHtml(studentAnswer || "No answer")}</span></div>`;
+        html += `<div class="text-sm text-gray-700">Student answer: <span class="font-semibold ${isCorrect === true ? "text-green-700" : (isCorrect === false ? "text-red-700" : "text-gray-800")}">${renderMarkdownWithMath(studentAnswer || "No answer")}</span></div>`;
         if (isCorrect === true) {
           html += `<div class="text-xs font-semibold text-green-700">Result: Correct</div>`;
         } else if (isCorrect === false) {

--- a/code/llmsite/tutor/views.py
+++ b/code/llmsite/tutor/views.py
@@ -159,6 +159,28 @@ def _try_extract_quiz_json(text: str):
     return None
 
 
+def _maybe_persist_quiz(session, assistant_reply_text):
+    """
+    If the assistant reply parses as a quiz JSON, supersede any existing
+    active quiz on this session and create a new active Quiz row so the
+    grading endpoint has something to score.
+    Returns True if a quiz was persisted.
+    """
+    quiz_json = _try_extract_quiz_json(assistant_reply_text)
+    if not quiz_json:
+        return False
+    Quiz.objects.filter(session=session, status="active").update(
+        status="submitted",
+        ended_at=timezone.now(),
+    )
+    Quiz.objects.create(
+        session=session,
+        status="active",
+        quiz_json=quiz_json,
+    )
+    return True
+
+
 @login_required
 def landing_page(request):
     """
@@ -668,6 +690,10 @@ def api_chat(request):
             DBChat.objects.create(session=session, role="user", message=msg)
             if not error_occurred and assistant_reply_text:
                 DBChat.objects.create(session=session, role="assistant", message=assistant_reply_text)
+                try:
+                    _maybe_persist_quiz(session, assistant_reply_text)
+                except Exception as qe:
+                    print(f"[api_chat] Quiz persistence error: {qe}")
 
             user_message_count = DBChat.objects.filter(session=session, role="user").count()
             if user_message_count % 5 == 0:
@@ -1268,6 +1294,13 @@ def api_grade_quiz(request):
         answers_json=answers_json,
         graded_json=graded_json,
     )
+
+    # Refresh cached StudentProgress so the dashboard quiz_average reflects
+    # this attempt immediately. A recompute failure must not fail grading.
+    try:
+        calculate_student_progress(request.user)
+    except Exception as pe:
+        print(f"[api_grade_quiz] Progress recompute error: {pe}")
 
     # Return structured JSON (frontend will parse and display it)
     feedback_json = json.dumps(graded_feedback)


### PR DESCRIPTION
## Summary
The quiz lifecycle was broken end-to-end even when the model emitted valid quiz JSON. This PR fixes the plumbing.

### What was broken
1. **`api_chat` never created a `Quiz` row.** The local-model path had no quiz-detection code at all, and the Gemini path (including its quiz-persistence logic) was wrapped in a triple-quoted string followed by `pass`, so nothing ran. `api_grade_quiz` therefore always found no active `Quiz` and returned `"No active quiz"`.
2. **`api_grade_quiz` never recomputed `StudentProgress`.** It set `Quiz.earned_pts` / `possible_pts` and created a `QuizAnswer`, but the dashboard `quiz_average` only refreshed every 5 chat messages — so a new attempt didn't show on the dashboard until the user typed more.
3. **Quiz card and read-only quiz views rendered question/answer text via `escapeHtml`**, so LaTeX math in quiz questions showed as raw `$...$`.
4. **The feedback-modal fallback path** inserted unescaped server text into `innerHTML` (pre-existing XSS hole on the rare non-JSON path).

### Changes
- **`tutor/views.py`** — Add `_maybe_persist_quiz(session, text)`: supersedes any active `Quiz` (flips it to `submitted`) and creates a new one when the reply parses as a quiz JSON. Called after the assistant `DBChat` row is written in `api_chat`, wrapped in `try/except` so malformed JSON can't break the chat flow.
- **`tutor/views.py`** — In `api_grade_quiz`, call `calculate_student_progress(request.user)` after the `QuizAnswer` is saved. Wrapped in `try/except` so a recompute failure never fails grading.
- **`tutor/templates/chat.html`** — `showQuizCard` and `renderReadOnlyQuiz` render question text, multiple-choice answer text, correct answers, and student answers through `renderMarkdownWithMath` so inline LaTeX renders.
- **`tutor/templates/chat.html`** — Escape `feedbackText` in the non-JSON fallback branch of the feedback modal.

### Out of scope
Prompt engineering to make models reliably emit valid quiz JSON is intentionally out of scope — this PR only fixes the plumbing so a correctly-formatted quiz flows end to end.

### Dependency
Stacked on [#60](https://github.com/Zelefant/CPTS421-AI-Tutor/pull/60). Merging #60 first is simplest; if merged in reverse order, git will still resolve cleanly.

## Test plan
- [x] Ask the chat for a quiz. When the model emits valid JSON, confirm the quiz card appears with rendered LaTeX in questions and answer choices.
- [ ] Submit answers (mix correct + wrong). Confirm the feedback modal shows per-question correct/incorrect indicators and renders any LaTeX in the explanation text.
- [ ] Inspect the DB: the relevant `Quiz` row is now `status='graded'` with `earned_pts` and `possible_pts` set, and a matching `QuizAnswer.graded_json` exists.
- [ ] Reload the student dashboard / progress detail. `quiz_average` reflects the new attempt **immediately**, without needing 5 more chat messages.
- [ ] Run `python manage.py refresh_all_progress --user-id=<id>` and confirm the recomputed `quiz_average` matches what the live path just wrote.
- [ ] Reload the session via the sidebar. The read-only quiz in chat history renders LaTeX in both question and answer choices, and (if submitted) shows the student's answer with correct/incorrect styling.
- [ ] Confirm the non-JSON fallback in the feedback modal escapes HTML (no XSS from a weird server response).

