### PR TITLE
Raise max_new_tokens to 1024 so quiz JSON does not truncate

### DIFF
--- a/code/llmsite/languagemodel_llama.py
+++ b/code/llmsite/languagemodel_llama.py
@@ -122,7 +122,7 @@ def StartChat(model, tokenizer, studentName, studentSchool, studentGrade, studen
     chat_prompt = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True, chat_template=chat_template)
 
     inputs = tokenizer(chat_prompt, return_tensors="pt").to(model.device)
-    outputs = model.generate(**inputs, max_new_tokens=350, eos_token_id=tokenizer.eos_token_id, pad_token_id=tokenizer.eos_token_id)
+    outputs = model.generate(**inputs, max_new_tokens=1024, eos_token_id=tokenizer.eos_token_id, pad_token_id=tokenizer.eos_token_id)
 
     #print("Decoded output (raw):")
     #print(tokenizer.decode(outputs[0]))
@@ -165,7 +165,7 @@ def SendMessage(model, tokenizer, messages, new_message):
 
     outputs = model.generate(
         **inputs,
-        max_new_tokens=350,
+        max_new_tokens=1024,
         temperature=0.4,
         eos_token_id=tokenizer.eos_token_id,
         pad_token_id=tokenizer.eos_token_id

--- a/code/llmsite/languagemodel_mistral.py
+++ b/code/llmsite/languagemodel_mistral.py
@@ -136,7 +136,7 @@ def _build_chat_text(tokenizer, messages, add_generation_prompt: bool) -> str:
     )
 
 
-def _generate_assistant_turn(model, tokenizer, messages_for_generation, max_new_tokens=350, temperature=0.4) -> str:
+def _generate_assistant_turn(model, tokenizer, messages_for_generation, max_new_tokens=1024, temperature=0.4) -> str:
     """
     Generates only the assistant continuation.
 

--- a/code/llmsite/languagemodel_qwen.py
+++ b/code/llmsite/languagemodel_qwen.py
@@ -178,7 +178,7 @@ def _generate_assistant_turn(
     model,
     tokenizer,
     messages_for_generation,
-    max_new_tokens=200,
+    max_new_tokens=1024,
     temperature=0.7,
     top_p=0.8,
     top_k=20


### PR DESCRIPTION
## Summary
Hotfix for PR #61. Quiz card was not popping up after merging — model output was truncated mid-JSON (cut off at ``\"correct\": \"`` on q3), so `_try_extract_quiz_json` could not parse the reply and the quiz never persisted. Frontend fell back to showing raw JSON.

Root cause: `max_new_tokens=200` (Qwen, the active module) is too small for a 3-question multiple-choice quiz JSON (~250–350 tokens). Mistral was 350 and Llama was 350 — same risk on any quiz past ~3 questions.

## Changes
- `languagemodel_qwen.py`: `_generate_assistant_turn` default `max_new_tokens` 200 → 1024
- `languagemodel_mistral.py`: `_generate_assistant_turn` default 350 → 1024
- `languagemodel_llama.py`: both `model.generate` calls (StartChat + SendMessage) 350 → 1024

## Test plan
- [ ] Pull `deployment_testing` after merge
- [ ] Start the server, log in, open a chat
- [ ] Ask: "give me a quiz on [topic]"
- [ ] Confirm the quiz card renders instead of raw JSON
- [ ] Submit answers and confirm grading works and dashboard quiz average updates

