### PR TITLE
Hide system prompts from chat history view (fixes #35)

### DIFF
--- a/code/llmsite/tutor/views.py
+++ b/code/llmsite/tutor/views.py
@@ -1037,7 +1037,14 @@ def api_session_messages(request, session_id):
         return JsonResponse({"error": "Access denied"}, status=403)
 
     chats = DBChat.objects.filter(session=session).order_by("created_at", "id")  # keep chronological order
-    messages = [{"role": c.role, "text": c.message} for c in chats]
+    # Hide system prompts from the UI. They are persisted so the LLM can
+    # reconstruct context in _load_messages_from_db, but they must never be
+    # shown to the student when viewing chat history (issue #35).
+    messages = [
+        {"role": c.role, "text": c.message}
+        for c in chats
+        if c.role != "system"
+    ]
 
     quiz_attempts = []
     quizzes = Quiz.objects.filter(session=session).order_by("started_at", "id")


### PR DESCRIPTION
Closes #35.

## Summary
When a student clicked on an old session, the LLM's system prompt was being rendered as a chat bubble. The system prompt contained the tutor's private instructions (don't give answers outright, output quiz JSON schema, etc.) and should never be visible to the student.

## Root cause
`api_new_session` / `api_session_init` persist every message returned by `StartChat`, including the `role=\"system\"` init prompt, because `_load_messages_from_db` rebuilds the LLM's full context from DB on every `api_chat` call. The persistence is correct — but `api_session_messages` (the endpoint the chat-history page calls) was dumping every row to the frontend verbatim, so the system message rendered as a bubble.

## Fix
One-line filter in `api_session_messages`: exclude `role=\"system\"` from the response. DB storage and LLM context reconstruction are unchanged, so model behavior is unaffected.

## Test plan
- [ ] Pull `deployment_testing` after merge
- [ ] Open a session with existing messages (one created before this fix)
- [ ] Confirm the system prompt bubble no longer appears at the top
- [ ] Send a new message in that session and confirm the LLM still responds normally (context still intact)
- [ ] Start a fresh session and confirm the greeting still renders correctly

