### PR TITLE
Chat UI cleanup: remove sidebar + duplicate init, rename/delete sessions, auto-title

### DIFF
--- a/code/llmsite/languagemodel_legacy.py
+++ b/code/llmsite/languagemodel_legacy.py
@@ -71,6 +71,46 @@ def Initialization(chat, studentName, studentSchool, studentGrade, studentClasse
     except Exception as e:
         return f",,,[Init Error] {e},,,"
 
+def DeriveSessionTitle(first_message: str) -> str:
+    """
+    Ask Gemini to summarize the student's first message into a 1-3 word topic
+    title. Returns "" when the message has no clear topic (gibberish, empty,
+    or LLM error) so callers can leave the session title alone.
+    """
+    text = (first_message or "").strip()
+    if not text:
+        return ""
+
+    load_dotenv()
+    api_key = os.getenv("GEMINI_API_KEY")
+    if not api_key:
+        return ""
+    genai.configure(api_key=api_key)
+
+    prompt = (
+        "You name chat sessions for a student tutoring app. "
+        "Read the student's first message and reply with ONLY a 1-3 word topic "
+        "title (no quotes, no punctuation, Title Case). "
+        "If the message is gibberish, empty, a greeting, or has no clear topic, "
+        "reply with exactly: NONE\n\n"
+        f"Message: {text}"
+    )
+
+    try:
+        model = genai.GenerativeModel("gemini-2.5-flash-lite")
+        resp = model.generate_content(prompt)
+        title = (resp.text or "").strip()
+    except Exception:
+        return ""
+
+    title = title.strip().strip('"').strip("'").strip()
+    if not title or title.upper() == "NONE":
+        return ""
+    if len(title) > 40:
+        title = title[:40].rstrip()
+    return title
+
+
 # Conversation
 def SendMessage(chat, message: str):
     try:
@@ -80,22 +120,26 @@ def SendMessage(chat, message: str):
 
         lower_msg = message.lower()
         if "quiz" in lower_msg or "practice exam" in lower_msg:
-            quiz_prompt = """
-            The student has requested a quiz. You must respond ONLY with JSON following this schema exactly:
-            {
-              "test": {
-                "q1": {
-                  "question": "...",
-                  "type": "multiple-choice",
-                  "answers": ["Answer 1", "Answer 2", "Answer 3", "Answer 4"],
-                  "correct": "index"
-                },
-                "q2": { ... }
-              }
-            }
-
-            Do not include any text outside the JSON. Create 2–4 Algebra 2 questions at the student's level.
-            """.strip()
+            quiz_prompt = (
+                f'The student\'s request: "{message}"\n\n'
+                "Generate a short quiz on the subject and topic the student "
+                "requested. If the request does not name a subject, infer it "
+                "from the prior conversation. Do NOT default to math.\n\n"
+                "Respond ONLY with JSON following this schema exactly:\n"
+                "{\n"
+                '  "test": {\n'
+                '    "q1": {\n'
+                '      "question": "...",\n'
+                '      "type": "multiple-choice",\n'
+                '      "answers": ["Answer 1", "Answer 2", "Answer 3", "Answer 4"],\n'
+                '      "correct": "index"\n'
+                "    },\n"
+                '    "q2": { ... }\n'
+                "  }\n"
+                "}\n\n"
+                "Include 2-4 multiple-choice questions at the student's grade "
+                "level. Do not include any text outside the JSON."
+            )
             response = chat.send_message(quiz_prompt)
         else:
             augmented = (rag_prefix + "\n\n---\nStudent message: " + message) if rag_prefix else message

--- a/code/llmsite/languagemodel_llama.py
+++ b/code/llmsite/languagemodel_llama.py
@@ -94,6 +94,38 @@ def InitializationPrompt(studentName, studentSchool, studentGrade, studentClasse
 
     return INITIALIZATION_PROMPT_2
 
+_TITLE_SYSTEM_PROMPT = (
+    "You name chat sessions for a student tutoring app. "
+    "Read the student's first message and reply with ONLY a 1-3 word topic "
+    "title (no quotes, no punctuation, Title Case). "
+    "If the message is gibberish, empty, a greeting, or has no clear topic, "
+    "reply with exactly: NONE"
+)
+
+def DeriveSessionTitle(model, tokenizer, first_message: str) -> str:
+    text = (first_message or "").strip()
+    if not text:
+        return ""
+    messages = [
+        {"role": "system", "content": _TITLE_SYSTEM_PROMPT},
+        {"role": "user", "content": f"Message: {text}"},
+    ]
+    try:
+        chat_template = """{% for message in messages %}<|{{ message['role'] }}|>\n{{ message['content'] }}\n{% endfor %}<|assistant|>\n"""
+        prompt = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True, chat_template=chat_template)
+        inputs = tokenizer(prompt, return_tensors="pt").to(model.device)
+        outputs = model.generate(**inputs, max_new_tokens=16, eos_token_id=tokenizer.eos_token_id, pad_token_id=tokenizer.eos_token_id)
+        reply = tokenizer.decode(outputs[0], skip_special_tokens=True)
+        raw = reply.split("<|assistant|>")[-1].strip()
+    except Exception:
+        return ""
+    title = (raw or "").strip().strip('"').strip("'").strip()
+    if not title or title.upper() == "NONE":
+        return ""
+    if len(title) > 40:
+        title = title[:40].rstrip()
+    return title
+
 def StartChat(model, tokenizer, studentName, studentSchool, studentGrade, studentClasses):
     print("Chat has started")
     messages = [

--- a/code/llmsite/languagemodel_mistral.py
+++ b/code/llmsite/languagemodel_mistral.py
@@ -171,6 +171,32 @@ def _generate_assistant_turn(model, tokenizer, messages_for_generation, max_new_
     assistant_text = tokenizer.decode(assistant_ids, skip_special_tokens=True).strip()
     return assistant_text
 
+_TITLE_SYSTEM_PROMPT = (
+    "You name chat sessions for a student tutoring app. "
+    "Read the student's first message and reply with ONLY a 1-3 word topic "
+    "title (no quotes, no punctuation, Title Case). "
+    "If the message is gibberish, empty, a greeting, or has no clear topic, "
+    "reply with exactly: NONE"
+)
+
+def DeriveSessionTitle(model, tokenizer, first_message: str) -> str:
+    text = (first_message or "").strip()
+    if not text:
+        return ""
+    messages = [
+        {"role": "system", "content": _TITLE_SYSTEM_PROMPT},
+        {"role": "user", "content": f"Message: {text}"},
+    ]
+    try:
+        raw = _generate_assistant_turn(model, tokenizer, messages, max_new_tokens=16, temperature=0.3)
+    except Exception:
+        return ""
+    title = (raw or "").strip().strip('"').strip("'").strip()
+    if not title or title.upper() == "NONE":
+        return ""
+    if len(title) > 40:
+        title = title[:40].rstrip()
+    return title
 
 def StartChat(model, tokenizer, studentName, studentSchool, studentGrade, studentClasses):
     print("Chat has started")

--- a/code/llmsite/tutor/templates/chat.html
+++ b/code/llmsite/tutor/templates/chat.html
@@ -2,10 +2,10 @@
 {% extends "base.html" %}
 {% block title %}Chat · AI Tutor{% endblock %}
 {% block content %}
-<div class="grid lg:grid-cols-[240px_minmax(0,1fr)_240px] gap-6">
+<div class="grid lg:grid-cols-[240px_minmax(0,1fr)] gap-6">
 
   <!-- Left Sidebar (Sessions) -->
-  <aside class="bg-white rounded-2xl border shadow-sm p-4">
+  <aside class="bg-white rounded-2xl border shadow-sm p-4 self-start">
     <div class="flex items-center justify-between mb-2">
       <h3 class="font-semibold">Sessions</h3>
       <button id="newSession" class="text-sm text-brand-600 hover:underline">New</button>
@@ -16,7 +16,7 @@
   </aside>
 
   <!-- Main Chat Window -->
-  <section class="bg-white rounded-2xl border shadow-sm flex flex-col">
+  <section class="bg-white rounded-2xl border shadow-sm flex flex-col w-full max-w-3xl mx-auto">
 
     <!-- Quiz Card (hidden by default, shown when quiz is active) -->
     <div id="quizCard" class="mb-4 hidden">
@@ -65,22 +65,6 @@
       </div>
     </div>
   </section>
-
-  <!-- Right Sidebar (Notes / Resources) -->
-  <aside class="bg-white rounded-2xl border shadow-sm p-4">
-    <h3 class="font-semibold">Lesson Notes</h3>
-    <ul class="list-disc list-inside text-sm text-gray-700 mt-2 space-y-1">
-      <li>Goal: Master factoring quadratics</li>
-      <li>Tip: Look for GCF first</li>
-      <li>Example: x² + 5x + 6 = (x+2)(x+3)</li>
-    </ul>
-
-    <h3 class="font-semibold mt-6">Resources</h3>
-    <div class="mt-2 space-y-2 text-sm">
-      <a class="block rounded-lg border p-2 hover:bg-gray-50" href="#">📄 PDF: Practice Problems</a>
-      <a class="block rounded-lg border p-2 hover:bg-gray-50" href="#">🎥 Video: Step-by-step Tutorial</a>
-    </div>
-  </aside>
 </div>
 {% endblock %}
 
@@ -119,6 +103,8 @@
   let quizAttempts = [];
   let quizAttemptIndex = 0;
   let quizActive = false;
+  let activeQuizText = null;
+  let activeQuizObj = null;
 
   // --- Main chat submit ---
   chatForm.addEventListener("submit", async (e) => {
@@ -149,6 +135,8 @@
 
       const quizObj = parseQuizJson(data.model_text);
       if (quizObj) {
+        activeQuizText = data.model_text;
+        activeQuizObj = quizObj;
         showQuizCard(quizObj);
       } else {
         appendMessage("model", data.model_text || "(no text)");
@@ -252,13 +240,9 @@
   // --- Quiz submit / grading ---
   submitQuizBtn.addEventListener("click", async (e) => {
     e.preventDefault();
-    const formData = new FormData(quizForm);
-    let csvAnswers = [];
-    for (let [, value] of formData.entries()) {
-      csvAnswers.push(value);
-    }
-    const csvString = csvAnswers
-      .map(v => typeof v === "string" && v.includes(",") ? `"${v}"` : v)
+    const formEntries = Array.from(new FormData(quizForm).entries());
+    const csvString = formEntries
+      .map(([, v]) => (typeof v === "string" && v.includes(",") ? `"${v}"` : v))
       .join(",");
 
     await showTypingAlert();
@@ -274,6 +258,10 @@
       });
       if (!res.ok) throw new Error(await res.text());
       const data = await res.json();
+      const attempt = buildLocalQuizAttempt(formEntries, data.model_text);
+      if (activeQuizText && attempt) {
+        appendMessage("model", activeQuizText, attempt);
+      }
       showQuizFeedbackModal(data.model_text);
     } catch (err) {
       showQuizFeedbackModal("Error: " + err.message);
@@ -281,9 +269,38 @@
     await removeTypingAlert();
     quizCard.classList.add("hidden");
     quizActive = false;
+    activeQuizText = null;
+    activeQuizObj = null;
     chatInput.disabled = false;
     document.getElementById("chat-send-button").disabled = false;
   });
+
+  // Build a quizAttempt shaped like /api/session/<id>/messages/ returns,
+  // so renderReadOnlyQuiz can show student answers + correctness immediately.
+  function buildLocalQuizAttempt(formEntries, gradeText) {
+    if (!activeQuizObj) return null;
+    let grades = {};
+    try {
+      grades = JSON.parse(gradeText) || {};
+    } catch {
+      grades = {};
+    }
+    const answersByQid = new Map(formEntries.map(([qid, val]) => [String(qid), String(val)]));
+    const items = Object.entries(activeQuizObj).map(([qid, qdata]) => {
+      const raw = answersByQid.get(qid) || "";
+      let studentAnswer = raw;
+      if (qdata && qdata.type === "multiple-choice" && Array.isArray(qdata.answers)) {
+        const idx = parseInt(raw, 10) - 1;
+        if (idx >= 0 && idx < qdata.answers.length) {
+          studentAnswer = String(qdata.answers[idx]);
+        }
+      }
+      const fb = String(grades[qid] || "");
+      const isCorrect = fb.startsWith("correct");
+      return { qid, student_answer: studentAnswer, is_correct: isCorrect };
+    });
+    return { has_submission: true, items };
+  }
 
   function showQuizFeedbackModal(feedbackText) {
     let formatted = "";
@@ -333,28 +350,6 @@
     quizFeedbackContent.innerText = "";
   });
 
-  // --- Initial chat setup ---
-  async function initializeChat() {
-    await showTypingAlert();
-    try {
-      const res = await fetch("{% url 'api_init' %}", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-CSRFToken": csrftoken
-        },
-        credentials: "same-origin",
-        body: JSON.stringify({})
-      });
-      if (!res.ok) throw new Error(await res.text());
-      const data = await res.json();
-      initialChat.innerText = data.model_text || "(no text)";
-    } catch (err) {
-      initialChat.innerText = "Error: " + err.message;
-    }
-    await removeTypingAlert();
-  }
-
   // --- Typing indicator helpers ---
   function showTypingAlert() {
     const alert = document.createElement("p");
@@ -393,6 +388,7 @@
 
   function renderReadOnlyQuiz(quizObj, quizAttempt) {
     const attemptMap = new Map();
+    const hasSubmission = !!(quizAttempt && quizAttempt.has_submission);
     if (quizAttempt && Array.isArray(quizAttempt.items)) {
       quizAttempt.items.forEach(item => {
         if (!item || !item.qid) return;
@@ -438,7 +434,7 @@
         html += `<div class="text-sm text-gray-700">Correct answer: <span class="font-semibold text-green-700">${escapeHtml(correct || "N/A")}</span></div>`;
       }
 
-      if (attempt && attempt.has_submission) {
+      if (hasSubmission && attempt) {
         html += `<div class="text-sm text-gray-700">Student answer: <span class="font-semibold ${isCorrect === true ? "text-green-700" : (isCorrect === false ? "text-red-700" : "text-gray-800")}">${escapeHtml(studentAnswer || "No answer")}</span></div>`;
         if (isCorrect === true) {
           html += `<div class="text-xs font-semibold text-green-700">Result: Correct</div>`;
@@ -463,6 +459,26 @@
       .replace(/'/g, "&#39;");
   }
 
+  // --- Build a single <li> for the sessions list ---
+  function renderSessionListItem(session) {
+    const li = document.createElement("li");
+    li.className = "session-item flex justify-between items-center p-2 rounded-lg hover:bg-gray-50 cursor-pointer";
+    li.dataset.sessionId = session.id;
+    li.innerHTML = `
+      <span class="session-title">${escapeHtml(session.title)}</span>
+      <div class="flex gap-2">
+        <button class="rename-btn text-blue-500" data-id="${session.id}">✏️</button>
+        <button class="delete-btn text-red-500" data-id="${session.id}">🗑️</button>
+      </div>
+    `;
+    li.addEventListener("click", (e) => {
+      if (e.target.classList.contains("rename-btn")) return;
+      if (e.target.classList.contains("delete-btn")) return;
+      loadSessionMessages(session.id);
+    });
+    return li;
+  }
+
   // --- New Session button ---
   document.getElementById("newSession").addEventListener("click", async () => {
     try {
@@ -479,14 +495,8 @@
       const data = await res.json();
       currentSessionId = data.id;
 
-      const li = document.createElement("li");
-      li.className = "p-2 rounded-lg hover:bg-gray-50 cursor-pointer";
-      li.dataset.sessionId = data.id;
-      li.innerText = data.title + " — " + new Date(data.createdAt).toLocaleString();
-      li.addEventListener("click", () => loadSessionMessages(data.id));
-
-      const sessionList = document.getElementById("sessionList");
-      sessionList.prepend(li);
+      const li = renderSessionListItem({ id: data.id, title: data.title });
+      document.getElementById("sessionList").prepend(li);
 
       chatLog.innerHTML = "";
       const initial = data.model_text || `Session created: ${data.title}`;
@@ -566,25 +576,7 @@
       const data = await res.json();
 
       data.sessions.forEach(session => {
-        const li = document.createElement("li");
-        li.className = "session-item flex justify-between items-center p-2 rounded-lg hover:bg-gray-50 cursor-pointer";
-        li.dataset.sessionId = session.id;
-
-        li.innerHTML = `
-          <span class="session-title">${session.title}</span>
-          <div class="flex gap-2">
-            <button class="rename-btn text-blue-500" data-id="${session.id}">✏️</button>
-            <button class="delete-btn text-red-500" data-id="${session.id}">🗑️</button>
-          </div>
-        `;
-
-        li.addEventListener("click", (e) => {
-          if (e.target.classList.contains("rename-btn")) return;
-          if (e.target.classList.contains("delete-btn")) return;
-          loadSessionMessages(session.id);
-        });
-
-        sessionList.appendChild(li);
+        sessionList.appendChild(renderSessionListItem(session));
       });
     } catch (err) {
       console.error("Failed to load sessions:", err.message);
@@ -644,7 +636,5 @@
     }
   }
 
-  // Kick off initial chat load
-  initializeChat();
 </script>
 {% endblock %}

--- a/code/llmsite/tutor/templates/chat.html
+++ b/code/llmsite/tutor/templates/chat.html
@@ -16,7 +16,7 @@
   </aside>
 
   <!-- Main Chat Window -->
-  <section class="bg-white rounded-2xl border shadow-sm flex flex-col w-full max-w-3xl mx-auto">
+  <section class="bg-white rounded-2xl border shadow-sm flex flex-col w-full max-w-3xl mx-auto h-[calc(100vh-7.5rem)]">
 
     <!-- Quiz Card (hidden by default, shown when quiz is active) -->
     <div id="quizCard" class="mb-4 hidden">
@@ -132,6 +132,13 @@
       });
       if (!res.ok) throw new Error(await res.text());
       const data = await res.json();
+
+      if (data.session_title && currentSessionId) {
+        const titleEl = document.querySelector(
+          `#sessionList li[data-session-id="${currentSessionId}"] .session-title`
+        );
+        if (titleEl) titleEl.textContent = data.session_title;
+      }
 
       const quizObj = parseQuizJson(data.model_text);
       if (quizObj) {

--- a/code/llmsite/tutor/templates/chat_history.html
+++ b/code/llmsite/tutor/templates/chat_history.html
@@ -16,7 +16,7 @@
   </aside>
 
   <!-- Main Chat Window -->
-  <section class="bg-white rounded-2xl border shadow-sm flex flex-col w-full max-w-3xl mx-auto">
+  <section class="bg-white rounded-2xl border shadow-sm flex flex-col w-full max-w-3xl mx-auto h-[calc(100vh-7.5rem)]">
 
     <div id="chatLog" class="flex-1 overflow-y-auto p-5 space-y-4">
       <div class="flex gap-3">

--- a/code/llmsite/tutor/templates/chat_history.html
+++ b/code/llmsite/tutor/templates/chat_history.html
@@ -2,10 +2,10 @@
 {% extends "base.html" %}
 {% block title %}Chat · AI Tutor{% endblock %}
 {% block content %}
-<div class="grid lg:grid-cols-[240px_minmax(0,1fr)_240px] gap-6">
+<div class="grid lg:grid-cols-[240px_minmax(0,1fr)] gap-6">
 
   <!-- Left Sidebar (Sessions) -->
-  <aside class="bg-white rounded-2xl border shadow-sm p-4">
+  <aside class="bg-white rounded-2xl border shadow-sm p-4 self-start">
     <div class="flex items-center justify-between mb-2">
       <h3 class="font-semibold">Sessions</h3>
     </div>
@@ -16,7 +16,7 @@
   </aside>
 
   <!-- Main Chat Window -->
-  <section class="bg-white rounded-2xl border shadow-sm flex flex-col">
+  <section class="bg-white rounded-2xl border shadow-sm flex flex-col w-full max-w-3xl mx-auto">
 
     <div id="chatLog" class="flex-1 overflow-y-auto p-5 space-y-4">
       <div class="flex gap-3">
@@ -27,22 +27,6 @@
       </div>
     </div>
   </section>
-
-  <!-- Right Sidebar (Notes / Resources) -->
-  <aside class="bg-white rounded-2xl border shadow-sm p-4">
-    <h3 class="font-semibold">Lesson Notes</h3>
-    <ul class="list-disc list-inside text-sm text-gray-700 mt-2 space-y-1">
-      <li>Goal: Master factoring quadratics</li>
-      <li>Tip: Look for GCF first</li>
-      <li>Example: x² + 5x + 6 = (x+2)(x+3)</li>
-    </ul>
-
-    <h3 class="font-semibold mt-6">Resources</h3>
-    <div class="mt-2 space-y-2 text-sm">
-      <a class="block rounded-lg border p-2 hover:bg-gray-50" href="#">📄 PDF: Practice Problems</a>
-      <a class="block rounded-lg border p-2 hover:bg-gray-50" href="#">🎥 Video: Step-by-step Tutorial</a>
-    </div>
-  </aside>
 </div>
 {% endblock %}
 

--- a/code/llmsite/tutor/views.py
+++ b/code/llmsite/tutor/views.py
@@ -14,7 +14,7 @@ import os
 import re
 import csv
 
-from languagemodel_legacy import DeriveSessionTitle
+# DeriveSessionTitle is dispatched per-module in _derive_session_title()
 from httpx import request
 from .models import Quiz, QuizAnswer, Session, Chat as DBChat, StudentProgress
 from .utils import is_teacher_or_admin, is_admin, calculate_student_progress, parse_csv_answers
@@ -37,6 +37,25 @@ def _get_local_llm_fns():
     elif settings.LLM_MODULE == "llama":
         from languagemodel_llama import InitModel, StartChat, SendMessage
         return InitModel, StartChat, SendMessage
+
+def _derive_session_title(first_message: str) -> str:
+    """Dispatch DeriveSessionTitle to the correct LLM module."""
+    try:
+        if settings.GEMINI_ENABLED:
+            from languagemodel_legacy import DeriveSessionTitle
+            return DeriveSessionTitle(first_message)
+        elif settings.LLM_MODULE == "qwen":
+            from languagemodel_qwen import DeriveSessionTitle
+            return DeriveSessionTitle(model, tokenizer, first_message)
+        elif settings.LLM_MODULE == "mistral":
+            from languagemodel_mistral import DeriveSessionTitle
+            return DeriveSessionTitle(model, tokenizer, first_message)
+        elif settings.LLM_MODULE == "llama":
+            from languagemodel_llama import DeriveSessionTitle
+            return DeriveSessionTitle(model, tokenizer, first_message)
+    except Exception as e:
+        print(f"[_derive_session_title] error: {e}")
+    return ""
 
 def ensure_llm_initialized():
     """
@@ -665,7 +684,7 @@ def api_chat(request):
             if session.title in ("", "New session"):
                 if not DBChat.objects.filter(session=session, role="user").exists():
                     try:
-                        derived = DeriveSessionTitle(msg)
+                        derived = _derive_session_title(msg)
                     except Exception as e:
                         print(f"[api_chat] DeriveSessionTitle error: {e}")
                         derived = ""

--- a/code/llmsite/tutor/views.py
+++ b/code/llmsite/tutor/views.py
@@ -14,7 +14,7 @@ import os
 import re
 import csv
 
-#from languagemodel_legacy import *
+from languagemodel_legacy import DeriveSessionTitle
 from httpx import request
 from .models import Quiz, QuizAnswer, Session, Chat as DBChat, StudentProgress
 from .utils import is_teacher_or_admin, is_admin, calculate_student_progress, parse_csv_answers
@@ -653,10 +653,27 @@ def api_chat(request):
         pass
     
     # Persist to DB: only persist user + assistant when there was no model error.
+    new_session_title = None
     try:
         session_id = request.session.get("session_id")
         if session_id:
             session = Session.objects.get(id=session_id, owner=request.user)
+
+            # Auto-title from the first user message if title is still the default.
+            # Ask the LLM for a 1-3 word topic; if it returns empty (gibberish /
+            # no clear topic) leave the title alone.
+            if session.title in ("", "New session"):
+                if not DBChat.objects.filter(session=session, role="user").exists():
+                    try:
+                        derived = DeriveSessionTitle(msg)
+                    except Exception as e:
+                        print(f"[api_chat] DeriveSessionTitle error: {e}")
+                        derived = ""
+                    if derived:
+                        session.title = derived
+                        session.save(update_fields=["title"])
+                        new_session_title = session.title
+
             DBChat.objects.create(session=session, role="user", message=msg)
             if not error_occurred and assistant_reply_text:
                 DBChat.objects.create(session=session, role="assistant", message=assistant_reply_text)
@@ -667,10 +684,12 @@ def api_chat(request):
     except Exception as e:
         print(f"Chat persistence or progress calc error: {e}")
 
+    payload = {"ok": True, "model_text": assistant_reply_text}
+    if new_session_title:
+        payload["session_title"] = new_session_title
     if error_occurred:
-        return JsonResponse({"ok": True, "model_text": assistant_reply_text, "error": True})
-    else:
-        return JsonResponse({"ok": True, "model_text": assistant_reply_text})
+        payload["error"] = True
+    return JsonResponse(payload)
 
 
 @require_http_methods(["POST"])


### PR DESCRIPTION
## Summary
- Removes the dead Lesson Notes sidebar
- Removes the duplicate `initializeChat()` function in `chat.html` — `loadSessionMessages` is the single entry point to `api_init` now
- New sessions can be renamed and deleted from the chat UI
- Quiz feedback modal rendering cleaned up
- Scroll-bound chat window
- Auto-titles new sessions from the first user message (LLM-derived 1–3 word topic). Dispatches through a new `_derive_session_title()` helper in `views.py` that picks the right module based on `LLM_MODULE` / `GEMINI_ENABLED`. `DeriveSessionTitle` added to the llama and mistral modules.

## Merged from deployment_testing
This branch was behind `deployment_testing` by several merges (PRs #55, #57, #58, #60, #61, #62, #63, docs). `deployment_testing` has been merged in; two conflicts in `chat.html` resolved:

1. **`initializeChat()` function** — deleted (this branch's removal wins; it was dead code after the cleanup)
2. **Student-answer line in `renderReadOnlyQuiz`** — kept this branch's `hasSubmission && attempt` guard, swapped `escapeHtml` → `renderMarkdownWithMath` so LaTeX in stored quiz answers still renders (PR #60 behavior preserved)

`views.py` / `languagemodel_llama.py` / `languagemodel_mistral.py` auto-merged. The `role != \"system\"` filter (PR #63) and `max_new_tokens=1024` hotfix (PR #62) both land alongside the new auto-titling.
