### PR TITLE
Hide student-info bootstrap user message from chat history (follow-up #35)

### DIFF
--- a/code/llmsite/tutor/views.py
+++ b/code/llmsite/tutor/views.py
@@ -1075,13 +1075,30 @@ def api_session_messages(request, session_id):
         return JsonResponse({"error": "Access denied"}, status=403)
 
     chats = DBChat.objects.filter(session=session).order_by("created_at", "id")  # keep chronological order
-    # Hide system prompts from the UI. They are persisted so the LLM can
+    # Hide bootstrap messages from the UI. They are persisted so the LLM can
     # reconstruct context in _load_messages_from_db, but they must never be
     # shown to the student when viewing chat history (issue #35).
+    # Two things to hide:
+    #   1. role="system" rows (the tutor instructions block)
+    #   2. The auto-generated "Here is your student information..." (local
+    #      LLMs) / "Name: ...\nSchool: ...\nGrade: ..." (Gemini) user message
+    #      that the backend sends on StartChat — the student never typed it.
+    def _is_bootstrap_user_message(text: str) -> bool:
+        if not text:
+            return False
+        stripped = text.lstrip()
+        if stripped.startswith("Here is your student information"):
+            return True
+        # Gemini bootstrap shape: starts with "Name:" plus School + Grade lines
+        if stripped.startswith("Name:") and "School:" in stripped and "Grade:" in stripped:
+            return True
+        return False
+
     messages = [
         {"role": c.role, "text": c.message}
         for c in chats
         if c.role != "system"
+        and not (c.role == "user" and _is_bootstrap_user_message(c.message))
     ]
 
     quiz_attempts = []


### PR DESCRIPTION
Follow-up to PR #63.

## What was still leaking
PR #63 filtered `role=\"system\"` rows from the chat-history API response. But on `StartChat`, the backend also persists a **user-role** message containing the student's name/school/grade/classes — the student never typed it, but it was rendering as a user bubble at the top of every old session.

Example leaked content:
```
Here is your student information:
Name: Jane Doe
School: George Washington High School
Grade: Sophomore
Current Classes: Algebra 2, History, AP Language/Composition
You will now introduce yourself...
```

## Fix
Extend the `api_session_messages` filter to also drop user-role rows whose content matches the bootstrap shape:
- starts with `\"Here is your student information\"` (local LLM modules: qwen / mistral / llama), **or**
- starts with `\"Name:\"` and contains `\"School:\"` + `\"Grade:\"` (Gemini path in `languagemodel_legacy.py`)

Content-shape match rather than position-based, so it also covers older sessions where ordering may drift. DB rows are unchanged — `_load_messages_from_db` still rebuilds the full LLM context on every turn.

