### PR TITLE
Fix off-by-one highlight of correct answer in read-only quiz view

### DIFF
--- a/code/llmsite/tutor/templates/chat.html
+++ b/code/llmsite/tutor/templates/chat.html
@@ -487,7 +487,10 @@
         qdata.answers.forEach((ans, i) => {
           const choiceText = String(ans ?? "");
           const choiceNumber = String(i + 1);
-          const isRightChoice = correct === choiceNumber || correct.toLowerCase() === choiceText.trim().toLowerCase();
+          // Model emits 0-based `correct` index (matches server grading in
+          // api_grade_quiz, which does `(user - 1) == correct`). Compare on
+          // the 0-based index, then fall back to a text match for robustness.
+          const isRightChoice = correct === String(i) || correct.toLowerCase() === choiceText.trim().toLowerCase();
           const isStudentChoice = studentAnswer && studentAnswer.trim().toLowerCase() === choiceText.trim().toLowerCase();
           const liClass = isRightChoice
             ? "bg-green-100 text-green-800 border border-green-300"

--- a/code/llmsite/tutor/templates/chat_history.html
+++ b/code/llmsite/tutor/templates/chat_history.html
@@ -113,7 +113,10 @@ function renderReadOnlyQuiz(quizObj, quizAttempt) {
       qdata.answers.forEach((ans, i) => {
         const choiceText = String(ans ?? "");
         const choiceNumber = String(i + 1);
-        const isRightChoice = correct === choiceNumber || correct.toLowerCase() === choiceText.trim().toLowerCase();
+        // Model emits 0-based `correct` index (matches server grading in
+        // api_grade_quiz, which does `(user - 1) == correct`). Compare on
+        // the 0-based index, then fall back to a text match for robustness.
+        const isRightChoice = correct === String(i) || correct.toLowerCase() === choiceText.trim().toLowerCase();
         const isStudentChoice = studentAnswer && studentAnswer.trim().toLowerCase() === choiceText.trim().toLowerCase();
         const liClass = isRightChoice
           ? "bg-green-100 text-green-800 border border-green-300"


### PR DESCRIPTION
## Symptom
When reopening a graded quiz from chat history, the **(Correct answer)** tag was highlighted on the wrong choice. Typical cases:

| Model's `correct` | Real answer (0-based) | What was highlighted |
|---|---|---|
| `\"0\"` | Choice 1 | nothing (no match) |
| `\"1\"` | Choice 2 | **Choice 1** |
| `\"2\"` | Choice 3 | **Choice 2** |
| `\"3\"` | Choice 4 | **Choice 3** |

## Root cause
`renderReadOnlyQuiz` (duplicated in `chat.html` and `chat_history.html`) compared the model's raw `correct` field against `String(i + 1)` — a **1-based display label** — but the model emits a **0-based index**. Server grading confirms that convention: `api_grade_quiz` does

```python
is_correct = (int(user_ans_str) - 1) == int(correct_str)
```

…where the user's radio value is 1-based and the model's `correct` is 0-based. Grading was right; rendering was off.

## Fix
Compare `correct === String(i)` instead of `String(i + 1)`. The existing lowercased text-match fallback is kept so a model that emits the answer text (e.g. `\"correct\": \"Photosynthesis\"`) still works.

Two-line change in each template + a comment explaining the convention so the next reader doesn't flip it back.

